### PR TITLE
css: add support for roman numbering

### DIFF
--- a/sphinx_ncs_theme/static/css/nordic.css
+++ b/sphinx_ncs_theme/static/css/nordic.css
@@ -339,3 +339,12 @@ kbd {
 .rst-columns {
   column-width: 18em;
 }
+
+/* add support for lists with roman numbering */
+
+.rst-content ol.lowerroman li {
+  list-style: lower-roman;
+}
+.rst-content ol.upperroman li {
+  list-style: upper-roman;
+}


### PR DESCRIPTION
The rtd theme does not have support for roman numerals in lists, even
though Sphinx supports it.
Add the required styling.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>