### PR TITLE
css: Fix styling for config options

### DIFF
--- a/sphinx_ncs_theme/static/css/nordic.css
+++ b/sphinx_ncs_theme/static/css/nordic.css
@@ -15,12 +15,13 @@
   color: #fff;
 }
 
-a.reference.internal[href^="#config-"] {
+a.reference.internal[href*="#config-"] {
   color: #404040;
   font-weight: 700;
   font-size: 75%;
   font-family: SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,Courier,monospace;
   border: 1px solid #e1e4e5;
+  background-color: white;
 }
 
 a.reference.internal[href="#sample-config"] {


### PR DESCRIPTION
The current style for sample config options that link to a
description in another page belonging to the sample is the
same as ref link style. The style fix renders the style similar
to what we have for library Kconfig options and for the
sample options that link to the description in the same
page as the link occurs.

Signed-off-by: Uma Praseeda <uma.praseeda@nordicsemi.no>