### PR TITLE
css: fix styling for numbered steps

### DIFF
--- a/sphinx_ncs_theme/static/css/nordic.css
+++ b/sphinx_ncs_theme/static/css/nordic.css
@@ -205,10 +205,10 @@ div#version_status {
 
 /* numbered steps */
 
-div.numbered-step > h2::before,
-div.numbered-step > h3::before,
-div.numbered-step > h4::before,
-div.numbered-step > h5::before {
+section.numbered-step > h2::before,
+section.numbered-step > h3::before,
+section.numbered-step > h4::before,
+section.numbered-step > h5::before {
   background: var(--docset-color);
   border-radius: 0.8em;
   -moz-border-radius: 0.8em;
@@ -238,27 +238,27 @@ h5 {
   counter-reset: step-count-h6;
 }
 
-div.numbered-step > h2::before {
+section.numbered-step > h2::before {
   counter-increment: step-count-h2;
   content: counter(step-count-h2);
 }
 
-div.numbered-step > h3::before {
+section.numbered-step > h3::before {
   counter-increment: step-count-h3;
   content: counter(step-count-h3);
 }
 
-div.numbered-step > h4::before {
+section.numbered-step > h4::before {
   counter-increment: step-count-h4;
   content: counter(step-count-h4);
 }
 
-div.numbered-step > h5::before {
+section.numbered-step > h5::before {
   counter-increment: step-count-h5;
   content: counter(step-count-h5);
 }
 
-div.numbered-step > h6::before {
+section.numbered-step > h6::before {
   counter-increment: step-count-h6;
   content: counter(step-count-h6);
 }
@@ -341,10 +341,10 @@ div.numbered-step > h6::before {
   color: var(--docset-color);
 }
 
-div.numbered-step > h2::before,
-div.numbered-step > h3::before,
-div.numbered-step > h4::before,
-div.numbered-step > h5::before {
+section.numbered-step > h2::before,
+section.numbered-step > h3::before,
+section.numbered-step > h4::before,
+section.numbered-step > h5::before {
   background: var(--docset-color);
 }
 


### PR DESCRIPTION
Fix styling for numbered steps
Looks like some recent changes removed formatting for the
following custom formatting:
.. rst-class:: numbered-step
examples:
[1.9.1](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.1/nrf/ug_matter_creating_accessory.html) where we have it correctly and
[latest](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/ug_matter_creating_accessory.html) where it is missing. PR adds a fix.
Output visible here:
http://developer.nordicsemi.com/nRF_Connect_SDK_dev/doc/PR-7459/nrf/gs_installing.html
http://developer.nordicsemi.com/nRF_Connect_SDK_dev/doc/PR-7459/nrf/ug_matter_creating_accessory.html# 

Signed-off-by: Uma Praseeda <uma.praseeda@nordicsemi.no>