### PR TITLE
css: fix guilabel split

### DIFF
--- a/sphinx_ncs_theme/static/css/nordic.css
+++ b/sphinx_ncs_theme/static/css/nordic.css
@@ -627,3 +627,7 @@ div.figure {
   padding-top: 0px;
   line-height: unset;
 }
+
+span.guilabel {
+  white-space: nowrap;
+}


### PR DESCRIPTION
Fix guilabel split occured at few instances
preview: 
http://developer.nordicsemi.com/nRF_Connect_SDK_dev/doc/PR-7459/nrf/ug_nrf9160_gs.html#connecting-to-nrf-cloud
current state:
https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/ug_nrf9160_gs.html#connecting-to-nrf-cloud


Signed-off-by: Richa Pandey <richa.pandey@nordicsemi.no>