### PR TITLE
gtm: added gtm iframe to content body

### DIFF
--- a/sphinx_ncs_theme/layout.html
+++ b/sphinx_ncs_theme/layout.html
@@ -14,6 +14,19 @@
   href="{{ pathto('_static/images/favicon.ico', 1) }}"
 />
 {% endblock %} {%- block extrabody %}
+
+{%- if theme_add_gtm|tobool %}
+<!-- Google Tag Manager (noscript) -->
+<noscript>
+  <iframe src="https://www.googletagmanager.com/ns.html?id={{ theme_gtm_id }}"
+  height="0"
+  width="0"
+  style="display:none;visibility:hidden">
+  </iframe>
+</noscript>
+<!-- End Google Tag Manager (noscript) -->
+{%- endif %}
+
 <div class="announcement"></div>
 <div class="d-print-none ncs-header">
   <div class="container-xl ncs-header-top">

--- a/sphinx_ncs_theme/layout.html
+++ b/sphinx_ncs_theme/layout.html
@@ -27,7 +27,11 @@
 <!-- End Google Tag Manager (noscript) -->
 {%- endif %}
 
-<div class="announcement"></div>
+<div class="announcement{{ '-fixed' if theme_set_default_announcement else '' }}">
+  {%- if theme_set_default_announcement|tobool %}
+  {{ theme_default_announcement_message }}
+  {%- endif %}
+</div>
 <div class="d-print-none ncs-header">
   <div class="container-xl ncs-header-top">
     <div class="row h-100">

--- a/sphinx_ncs_theme/static/css/nordic.css
+++ b/sphinx_ncs_theme/static/css/nordic.css
@@ -170,6 +170,13 @@ kbd {
   display: none;
 }
 
+.announcement-fixed {
+  background-color: #f0f0a8;
+  padding: 5px;
+  text-align: center;
+  display: block;
+}
+
 .ncs-header {
   background: url("../images/header-bg.svg");
   background-size: cover;

--- a/sphinx_ncs_theme/theme.conf
+++ b/sphinx_ncs_theme/theme.conf
@@ -19,3 +19,5 @@ vcs_pageview_mode =
 docset =
 docsets =
 standalone = False
+add_gtm = False
+gtm_id =

--- a/sphinx_ncs_theme/theme.conf
+++ b/sphinx_ncs_theme/theme.conf
@@ -21,3 +21,5 @@ docsets =
 standalone = False
 add_gtm = False
 gtm_id =
+set_default_announcement = False
+default_announcement_message =


### PR DESCRIPTION
Added a noscript Google Tag Manager iframe to the start of the html body. This will be hidden by default, but can be set with the option `add_gtm`. The GTM ID can be set with the option `gtm_id`.

Also added options to add a default announcement banner.