### PR TITLE
theme: add support for subtitle

### DIFF
--- a/sphinx_ncs_theme/layout.html
+++ b/sphinx_ncs_theme/layout.html
@@ -13,6 +13,26 @@
   rel="shortcut icon"
   href="{{ pathto('_static/images/favicon.ico', 1) }}"
 />
+{% endblock %} {%- block sidebartitle %}
+
+<a href="{{ pathto(root_doc|default(master_doc)) }}">
+  {{ project }}
+</a>
+
+{%- if theme_subtitle %}
+  <div class="ncs-subtitle">
+    {{ theme_subtitle }}
+  </div>
+{%- endif %}
+
+{%- if theme_display_version %}
+  <div class="version">
+    {{ version }}
+  </div>
+{%- endif %}
+
+{%- include "searchbox.html" %}
+
 {% endblock %} {%- block extrabody %}
 
 {%- if theme_add_gtm|tobool %}

--- a/sphinx_ncs_theme/static/css/nordic.css
+++ b/sphinx_ncs_theme/static/css/nordic.css
@@ -310,10 +310,13 @@ kbd {
 
 .wy-side-nav-search > a {
   font-size: 150%;
+  margin-bottom: unset;
+  padding: unset;
 }
 
 .wy-side-nav-search > div.version {
   color: unset;
+  margin-top: unset;
 }
 
 .searchformwrapper {
@@ -350,6 +353,11 @@ kbd {
 
 .rst-versions {
   display: none !important;
+}
+
+.ncs-subtitle {
+  color: rgba(0, 169, 206, 0.65);
+  margin-bottom: 0.5rem;
 }
 
 /*******************************************************************************

--- a/sphinx_ncs_theme/theme.conf
+++ b/sphinx_ncs_theme/theme.conf
@@ -23,3 +23,4 @@ add_gtm = False
 gtm_id =
 set_default_announcement = False
 default_announcement_message =
+subtitle =


### PR DESCRIPTION
Allow displaying a subtitle below project name, useful to identify projects that are upstream forks with a clearly visible tag.