### PR TITLE
fix crash if no theme_docsets is specified

### DIFF
--- a/sphinx_ncs_theme/layout.html
+++ b/sphinx_ncs_theme/layout.html
@@ -117,6 +117,7 @@
             >
               <span class="navbar-toggler-icon"></span>
             </button>
+            {%- if theme_docsets %}
             <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
               <ul class="navbar-nav">
                 {%- for name, config in theme_docsets.items() %}
@@ -131,6 +132,7 @@
                 {%- endfor %}
               </ul>
             </div>
+            {% endif %}
           </nav>
         </div>
       </div>


### PR DESCRIPTION
I've used the same approach as found in versions.html, without it there is exception:
jinja2.exceptions.UndefinedError: 'str object' has no attribute 'items'